### PR TITLE
feat: 회원 소셜 연동 도메인 추가

### DIFF
--- a/src/main/kotlin/com/service/authorization/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/service/authorization/config/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package com.service.authorization.config
 
 import com.service.authorization.federatedIdentity.FederatedIdentityConfigurer
+import com.service.authorization.user.CustomOAuth2UserService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
@@ -8,14 +9,18 @@ import org.springframework.core.annotation.Order
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.core.Authentication
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration
 import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings
+import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint
 import java.util.*
@@ -78,5 +83,18 @@ class SecurityConfig(
                 .oidcUserInfoEndpoint("/connect/v1/userinfo")
                 .oidcClientRegistrationEndpoint("/connect/v1/register")
                 .build()
+    }
+
+
+    @Bean
+    fun tokenCustomizer(userInfoService: CustomOAuth2UserService): OAuth2TokenCustomizer<JwtEncodingContext> {
+        return OAuth2TokenCustomizer { context: JwtEncodingContext ->
+            if (OidcParameterNames.ID_TOKEN == context.tokenType.value) {
+                println("test: ${context.getPrincipal<Authentication>()}")
+                //val userInfo: OidcUserInfo = userInfoService.loadUser(
+                        //context.getPrincipal<Authentication>().name)
+                //context.claims.claims { claims: MutableMap<String?, Any?> -> claims.putAll(userInfo.claims) }
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/service/authorization/config/UserSecurityConfig.kt
+++ b/src/main/kotlin/com/service/authorization/config/UserSecurityConfig.kt
@@ -3,6 +3,7 @@ package com.service.authorization.config
 import com.service.authorization.user.CustomOAuth2UserService
 import com.service.authorization.user.UserNameAndPasswordService
 import com.service.authorization.user.UserService
+import com.service.authorization.userFederatedIdentity.UserFederatedIdentityService
 import com.service.authorization.userRole.UserRoleService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,6 +20,6 @@ class UserSecurityConfig {
             UserNameAndPasswordService(userService, userRoleService)
 
     @Bean
-    fun customOAuth2UserService(userService: UserService, userRoleService: UserRoleService): OAuth2UserService<OidcUserRequest, OidcUser> =
-            CustomOAuth2UserService(userService, userRoleService)
+    fun customOAuth2UserService(userService: UserService, userRoleService: UserRoleService, userFederatedIdentityService: UserFederatedIdentityService): OAuth2UserService<OidcUserRequest, OidcUser> =
+            CustomOAuth2UserService(userService, userRoleService, userFederatedIdentityService)
 }

--- a/src/main/kotlin/com/service/authorization/user/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/service/authorization/user/CustomOAuth2UserService.kt
@@ -1,5 +1,6 @@
 package com.service.authorization.user
 
+import com.service.authorization.userFederatedIdentity.UserFederatedIdentityService
 import com.service.authorization.userRole.UserRoleService
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
@@ -9,10 +10,14 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser
 
 class CustomOAuth2UserService(
         private val userService: UserService,
-        private val userRoleService: UserRoleService
+        private val userRoleService: UserRoleService,
+        private val userFederatedIdentityService: UserFederatedIdentityService
 ) : OAuth2UserService<OidcUserRequest, OidcUser> {
 
     override fun loadUser(userRequest: OidcUserRequest): OidcUser {
+        // 계정 - 소셜이 없는 경우: 계정 소셜  추가
+        // 계정은 있고 소셜이 없는 경우: 계정에 소셜 연동
+        val subject = userRequest.idToken.subject
         val email = userRequest.idToken.email
         val userDetail = User.withDefaultPasswordEncoder()
                 .username(email)
@@ -21,7 +26,7 @@ class CustomOAuth2UserService(
                 .build()
         val user = userService.getBy(email = email) ?: userService.save(userDetail)
         val userRoles = userRoleService.getAllOrSave(user.id, userDetail.authorities.toList())
-
+        userFederatedIdentityService.getOrSave(subject, user.id, userRequest.clientRegistration.registrationId)
         return DefaultOidcUser(userRoles, userRequest.idToken)
     }
 }

--- a/src/main/kotlin/com/service/authorization/user/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/service/authorization/user/CustomOAuth2UserService.kt
@@ -1,7 +1,6 @@
 package com.service.authorization.user
 
 import com.service.authorization.userRole.UserRoleService
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
@@ -21,13 +20,7 @@ class CustomOAuth2UserService(
                 .roles("USER")
                 .build()
         val user = userService.getBy(email = email) ?: userService.save(userDetail)
-        val userRoles = userRoleService.getAllBy(userId = user.id)
-                .map { SimpleGrantedAuthority(it.role) }.let { it ->
-                    if (!it.containsAll(userDetail.authorities)) {
-                        return@let userRoleService.saveAll(user.id, userDetail.authorities.toList()).map { SimpleGrantedAuthority(it.role) }
-                    }
-                    it
-                }
+        val userRoles = userRoleService.getAllOrSave(user.id, userDetail.authorities.toList())
 
         return DefaultOidcUser(userRoles, userRequest.idToken)
     }

--- a/src/main/kotlin/com/service/authorization/userFederatedIdentity/UserFederatedIdentity.kt
+++ b/src/main/kotlin/com/service/authorization/userFederatedIdentity/UserFederatedIdentity.kt
@@ -1,0 +1,31 @@
+package com.service.authorization.userFederatedIdentity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+
+/**
+ * 회원 연동 테이블
+ */
+@Entity
+class UserFederatedIdentity(
+        /**
+         * id
+         */
+        @Id
+        val id: String,
+
+        /**
+         * userId
+         */
+        val userId: String,
+
+        /**
+         * 제공자 등록 id
+         */
+        val registrationId: String
+) {
+    companion object {
+        fun of(id: String, userId: String, registrationId: String) =
+                UserFederatedIdentity(id, userId, registrationId)
+    }
+}

--- a/src/main/kotlin/com/service/authorization/userFederatedIdentity/UserFederatedIdentityRepository.kt
+++ b/src/main/kotlin/com/service/authorization/userFederatedIdentity/UserFederatedIdentityRepository.kt
@@ -1,0 +1,7 @@
+package com.service.authorization.userFederatedIdentity
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserFederatedIdentityRepository: JpaRepository<UserFederatedIdentity, String> {
+
+}

--- a/src/main/kotlin/com/service/authorization/userFederatedIdentity/UserFederatedIdentityService.kt
+++ b/src/main/kotlin/com/service/authorization/userFederatedIdentity/UserFederatedIdentityService.kt
@@ -1,0 +1,19 @@
+package com.service.authorization.userFederatedIdentity
+
+import org.springframework.stereotype.Service
+
+@Service
+class UserFederatedIdentityService(
+        private val userFederatedIdentityRepository: UserFederatedIdentityRepository
+) {
+
+    fun save(id: String, userId: String, provider: String) =
+            userFederatedIdentityRepository.save(
+                    UserFederatedIdentity.of(id, userId, provider)
+            )
+
+    fun getBy(id: String): UserFederatedIdentity? = userFederatedIdentityRepository.findById(id).orElse(null)
+
+    fun getOrSave(id: String, userId: String, provider: String): UserFederatedIdentity =
+            getBy(id) ?: save(id, userId, provider)
+}

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
@@ -1,12 +1,21 @@
 package com.service.authorization.userRole
 
 import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Service
 
 @Service
 class UserRoleService(
         private val userRoleRepository: UserRoleRepository
 ) {
+
+    fun getAllOrSave(userId: String, authorities: List<GrantedAuthority>): List<GrantedAuthority> {
+        val roles = getAllBy(userId = userId).map { SimpleGrantedAuthority(it.role) }
+        if (roles.containsAll(authorities)) {
+            return roles
+        }
+        return saveAll(userId, authorities).map { SimpleGrantedAuthority(it.role) }
+    }
 
     fun saveAll(userId: String, authorities: List<GrantedAuthority>): List<UserRole> =
             authorities.map { UserRole.of(userId, it) }.run {

--- a/src/main/resources/db/migration/V202302281618__user_identity_provider.sql
+++ b/src/main/resources/db/migration/V202302281618__user_identity_provider.sql
@@ -1,0 +1,7 @@
+-- 회원 연동 id 테이블
+CREATE TABLE user_federated_identity (
+    id varchar(100) UNIQUE NOT NULL,
+    user_id varchar(100) NOT NULL,
+    registration_id varchar(100) NOT NULL,
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
## 요약
- 회원 소셜 연동  도메인 추가
- 회원 & 소셜이 없는 경우 -> 회원, 소셜 데이터 추가
- 회원 존재하고 소셜이 없는 경우 -> 소셜 데이터 추가
- 회원 & 소셜이 있는 경우 -> 처리하지 않음