### PR TITLE
test: login api 테스트 검증 방식 수정

### DIFF
--- a/src/test/kotlin/com/service/authorization/client/TestRestTemplateExtension.kt
+++ b/src/test/kotlin/com/service/authorization/client/TestRestTemplateExtension.kt
@@ -1,0 +1,21 @@
+package com.service.authorization.client
+
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
+
+fun TestRestTemplate.login(port: Int, username: String = "user", password: String = "password"): ResponseEntity<String> {
+    val url = "http://localhost:$port"
+    val headers = HttpHeaders().apply {
+        this["content-type"] = "application/x-www-form-urlencoded"
+    }
+    val body = LinkedMultiValueMap<String, Any>().apply {
+        this["username"] = username
+        this["password"] = password
+    }
+    val entity = HttpEntity(body, headers)
+    return exchange("$url/login", HttpMethod.POST, entity, String::class.java)
+}

--- a/src/test/kotlin/com/service/authorization/htpHeader/HttpHeaderExtension.kt
+++ b/src/test/kotlin/com/service/authorization/htpHeader/HttpHeaderExtension.kt
@@ -1,0 +1,14 @@
+package com.service.authorization.htpHeader
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpHeaders.SET_COOKIE
+import org.springframework.util.Base64Utils
+
+/**
+ * format
+ * set-cookie: SESSION=xxxx;a=b
+ */
+fun HttpHeaders.encodedSessionId() =
+        this[SET_COOKIE]!!.first().split(";").first { it.startsWith("SESSION") }.split("=").last()
+
+fun HttpHeaders.sessionId() = String(Base64Utils.decodeFromString(encodedSessionId()))

--- a/src/test/kotlin/com/service/authorization/redis/RedisTemplateExtension.kt
+++ b/src/test/kotlin/com/service/authorization/redis/RedisTemplateExtension.kt
@@ -1,0 +1,10 @@
+package com.service.authorization.redis
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.session.data.redis.RedisSessionRepository.DEFAULT_KEY_NAMESPACE
+
+/**
+ * 인증 여부 확인
+ */
+fun RedisTemplate<String, String>.authenticated(sessionId: String): Boolean =
+        opsForHash<String, String>().keys("$DEFAULT_KEY_NAMESPACE:sessions:$sessionId").contains("sessionAttr:SPRING_SECURITY_CONTEXT")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,8 @@
 spring:
   main:
     allow-bean-definition-overriding: true
-
+  session:
+    timeout: 5
 logging:
   level:
     root: INFO


### PR DESCRIPTION
## 요약
- 로그인 요청후 응답 헤더에서 session ID 를 가져오고, redis 에 저장된 session 키 정보를 체크한다