### PR TITLE
refactor: regiser-client 페이지 데이터 조회 로직 추가

### DIFF
--- a/src/main/kotlin/com/service/authorization/MigrationRunner.kt
+++ b/src/main/kotlin/com/service/authorization/MigrationRunner.kt
@@ -1,28 +1,51 @@
 package com.service.authorization
 
+import com.service.authorization.registeredClient.CustomRegisteredClientRepository
 import com.service.authorization.user.UserService
 import com.service.authorization.userRole.UserRoleService
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod
+import org.springframework.security.oauth2.core.oidc.OidcScopes
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 class MigrationRunner(
         private val userService: UserService,
-        private val userRoleService: UserRoleService
-): ApplicationRunner {
+        private val userRoleService: UserRoleService,
+        private val registeredClientRepository: CustomRegisteredClientRepository
+) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
         val userDetails: UserDetails = User.withDefaultPasswordEncoder()
                 .username("user")
                 .password("password")
                 .roles("USER")
                 .build()
-        if(userService.getBy(userDetails.username) != null) {
+        if (userService.getBy(userDetails.username) != null) {
             return
         }
         val user = userService.save(userDetails)
-        userRoleService.saveAll(user.id,  userDetails.authorities.toList())
+        userRoleService.saveAll(user.id, userDetails.authorities.toList())
+        val registeredClient = RegisteredClient.withId(UUID.randomUUID().toString())
+                .clientId("public-client")
+                .clientSecret("{noop}public-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .redirectUri("https://oauthdebugger.com/debug")
+                .scope(OidcScopes.OPENID)
+                .scope(OidcScopes.PROFILE)
+                .scope("message.read")
+                .scope("message.write")
+                .clientSettings(ClientSettings.builder().requireAuthorizationConsent(true).build())
+                .build()
+        registeredClientRepository.findByClientId("public-client") ?: registeredClientRepository.save(registeredClient)
     }
 }

--- a/src/main/kotlin/com/service/authorization/registeredClient/RegisteredClientConfig.kt
+++ b/src/main/kotlin/com/service/authorization/registeredClient/RegisteredClientConfig.kt
@@ -3,12 +3,6 @@ package com.service.authorization.registeredClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.jdbc.core.JdbcOperations
-import org.springframework.security.oauth2.core.AuthorizationGrantType
-import org.springframework.security.oauth2.core.ClientAuthenticationMethod
-import org.springframework.security.oauth2.core.oidc.OidcScopes
-import org.springframework.security.oauth2.server.authorization.client.RegisteredClient
-import org.springframework.security.oauth2.server.authorization.settings.ClientSettings
-import java.util.*
 
 
 @Configuration
@@ -16,20 +10,6 @@ class RegisteredClientConfig {
 
     @Bean
     fun registeredClientRepository(jdbcOperations: JdbcOperations): CustomRegisteredClientRepository? {
-        val registeredClient = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("public-client")
-                .clientSecret("{noop}public-secret")
-                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-                .redirectUri("https://oauthdebugger.com/debug")
-                .scope(OidcScopes.OPENID)
-                .scope(OidcScopes.PROFILE)
-                .scope("message.read")
-                .scope("message.write")
-                .clientSettings(ClientSettings.builder().requireAuthorizationConsent(true).build())
-                .build()
         return CustomRegisteredClientRepository(jdbcOperations)
     }
 }

--- a/src/main/kotlin/com/service/authorization/registeredClient/RegisteredClientController.kt
+++ b/src/main/kotlin/com/service/authorization/registeredClient/RegisteredClientController.kt
@@ -1,14 +1,17 @@
 package com.service.authorization.registeredClient
 
 import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.servlet.ModelAndView
 
 @Controller
-class RegisteredClientController {
+class RegisteredClientController(
+        private val registeredClientService: RegisteredClientService
+) {
 
     @GetMapping("/register-client")
-    fun getView(modelAndView: ModelAndView): String {
+    fun getView(model: Model): String {
+        model.addAttribute("clients", registeredClientService.getBy().map { it.toView() })
         return "register-client/main"
     }
 }

--- a/src/main/kotlin/com/service/authorization/registeredClient/RegisteredClientView.kt
+++ b/src/main/kotlin/com/service/authorization/registeredClient/RegisteredClientView.kt
@@ -1,0 +1,25 @@
+package com.service.authorization.registeredClient
+
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient
+
+data class RegisteredClientView(
+        val id: String,
+        val clientId: String,
+        val clientSecret: String?,
+        val clientName: String,
+        val clientAuthenticationMethods: String?,
+        val authorizationGrantTypes: String?,
+        val redirectUris: String,
+        val scopes: String
+)
+
+fun RegisteredClient.toView() = RegisteredClientView(
+        id = id,
+        clientId = clientId,
+        clientSecret = clientSecret,
+        clientName = clientName,
+        clientAuthenticationMethods = clientAuthenticationMethods.joinToString(separator = ",") { it.value },
+        authorizationGrantTypes = authorizationGrantTypes.joinToString(separator = ",") { it.value },
+        redirectUris = redirectUris.joinToString(separator = ","),
+        scopes = scopes.joinToString(separator = ",")
+)

--- a/src/main/resources/templates/console/main.html
+++ b/src/main/resources/templates/console/main.html
@@ -2,13 +2,13 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
 <head th:replace="head/head::head"></head>
 <body>
-<div class="container">
+<div class="container-fluid">
     <div class="row border">
         헤더
     </div>
     <div class="row">
         <div th:replace="menu/menu::menu"></div>
-        <div class="col-xs-9 col-sm-9 col-md-9 col-lg-9 vh-100 border ">
+        <div class="overflow-auto col-xs-9 col-sm-9 col-md-9 col-lg-9 vh-100 border ">
             <div class="row">오른쪽</div>
         </div>
     </div>

--- a/src/main/resources/templates/register-client/main.html
+++ b/src/main/resources/templates/register-client/main.html
@@ -2,14 +2,40 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
 <head th:replace="head/head::head"></head>
 <body>
-<div class="container">
+<div class="container-fluid">
     <div class="row border">
         헤더
     </div>
     <div class="row">
         <div th:replace="menu/menu::menu"></div>
-        <div class="col-xs-9 col-sm-9 col-md-9 col-lg-9 vh-100 border ">
-            <div class="row">registered client</div>
+
+        <div class="overflow-auto col-xs-9 col-sm-9 col-md-9 col-lg-9 vh-100 border ">
+            <table class="table table-bordered table-hover">
+                <thead>
+                <tr>
+                    <th><span>id</span></th>
+                    <th><span>client-id</span></th>
+                    <th><span>client-name</span></th>
+                    <th><span>client-secret</span></th>
+                    <th><span>client-authentication-methods</span></th>
+                    <th><span>authorization-grant-types</span></th>
+                    <th><span>redirect-uris</span></th>
+                    <th><span>scopes</span></th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="client : ${clients}">
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.id}" style="max-width: 150px;"></span></td>
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.clientId}" style="max-width: 150px;"></span></td>
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.clientName}" style="max-width: 150px;"></span></td>
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.clientSecret}"> </span></td>
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.clientAuthenticationMethods}" style="max-width: 150px;"></span></td>
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.authorizationGrantTypes}" style="max-width: 150px;"></span></td>
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.redirectUris}" style="max-width: 150px;"></span></td>
+                    <td> <span class="d-inline-block text-truncate" th:text="${client.scopes}" style="max-width: 150px;"></span></td>
+                </tr>
+                </tbody>
+            </table>
         </div>
     </div>
     <div class="row border">Footer</div>


### PR DESCRIPTION
## 요약
- /register-client 로 요청시, 페이지로 이동후, 테이블 형태로 데이터를 표시하도록 처리
- UI 템플릿 수정