### PR TITLE
feat: 회원 권한 생성 페이지 로직 추가 & 리팩토링 & 스키마 수정

### DIFF
--- a/src/main/kotlin/com/service/authorization/MigrationRunner.kt
+++ b/src/main/kotlin/com/service/authorization/MigrationRunner.kt
@@ -5,7 +5,7 @@ import com.service.authorization.user.UserCreationPayload
 import com.service.authorization.user.UserService
 import com.service.authorization.userRole.UserRoleCreationPayload
 import com.service.authorization.userRole.UserRoleService
-import com.service.authorization.userRole.UserRoleType
+import com.service.authorization.userRole.UserRoleName
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.security.oauth2.core.AuthorizationGrantType
@@ -24,7 +24,7 @@ class MigrationRunner(
 ) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
         val userPayload = UserCreationPayload("user", "password")
-        val userRolePayload = UserRoleCreationPayload(UserRoleType.ROLE_ADMIN)
+        val userRolePayload = UserRoleCreationPayload(UserRoleName.ROLE_ADMIN)
         if (userService.getBy(userPayload.email) == null) {
             val user = userService.save(userPayload)
             userRoleService.save(user.id, userRolePayload)

--- a/src/main/kotlin/com/service/authorization/MigrationRunner.kt
+++ b/src/main/kotlin/com/service/authorization/MigrationRunner.kt
@@ -1,12 +1,13 @@
 package com.service.authorization
 
 import com.service.authorization.registeredClient.CustomRegisteredClientRepository
+import com.service.authorization.user.UserCreationPayload
 import com.service.authorization.user.UserService
+import com.service.authorization.userRole.UserRoleCreationPayload
 import com.service.authorization.userRole.UserRoleService
+import com.service.authorization.userRole.UserRoleType
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
-import org.springframework.security.core.userdetails.User
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.oauth2.core.AuthorizationGrantType
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod
 import org.springframework.security.oauth2.core.oidc.OidcScopes
@@ -22,15 +23,11 @@ class MigrationRunner(
         private val registeredClientRepository: CustomRegisteredClientRepository
 ) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
-        val userDetails: UserDetails = User.withDefaultPasswordEncoder()
-                .username("user")
-                .password("password")
-                .roles("USER")
-                .roles("ADMIN")
-                .build()
-        if (userService.getBy(userDetails.username) == null) {
-            val user = userService.save(userDetails)
-            userRoleService.saveAll(user.id, userDetails.authorities.toList())
+        val userPayload = UserCreationPayload("user", "password")
+        val userRolePayload = UserRoleCreationPayload(UserRoleType.ROLE_ADMIN)
+        if (userService.getBy(userPayload.email) == null) {
+            val user = userService.save(userPayload)
+            userRoleService.save(user.id, userRolePayload)
         }
         val registeredClients = listOf(
                 RegisteredClient.withId(UUID.randomUUID().toString())

--- a/src/main/kotlin/com/service/authorization/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/service/authorization/config/SecurityConfig.kt
@@ -1,7 +1,7 @@
 package com.service.authorization.config
 
-import com.service.authorization.config.SecurityConstants.ROLE_ADMIN
 import com.service.authorization.federatedIdentity.FederatedIdentityConfigurer
+import com.service.authorization.userRole.UserRoleName
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
@@ -55,7 +55,7 @@ class SecurityConfig(
         http.authorizeHttpRequests { authorize ->
             authorize
                     .requestMatchers("/assets/**", "/webjars/**", "/", "", "/login/**", "/login").permitAll()
-                    .requestMatchers("/console/**").hasAnyAuthority(ROLE_ADMIN)
+                    .requestMatchers("/console/**").hasAnyAuthority(UserRoleName.ROLE_ADMIN.name)
                     .anyRequest().authenticated()
         }
                 .formLogin()

--- a/src/main/kotlin/com/service/authorization/config/SecurityConstants.kt
+++ b/src/main/kotlin/com/service/authorization/config/SecurityConstants.kt
@@ -3,9 +3,5 @@ package com.service.authorization.config
 object SecurityConstants {
     val SUCCESS_URL = "/console"
 
-    val ROLE_ADMIN = "ROLE_ADMIN"
-
-    val ROLE_USER = "ROLE_USER"
-
     val PASSWORD_PREFIX = "{noop}"
 }

--- a/src/main/kotlin/com/service/authorization/oauth/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/service/authorization/oauth/CustomOAuth2UserService.kt
@@ -1,16 +1,13 @@
 package com.service.authorization.oauth
 
-import com.service.authorization.config.SecurityConstants
 import com.service.authorization.user.UserCreationPayload
 import com.service.authorization.user.UserDTO
 import com.service.authorization.user.UserService
 import com.service.authorization.user.toDTO
 import com.service.authorization.userFederatedIdentity.UserFederatedIdentityService
-import com.service.authorization.userRole.UserRole
-import com.service.authorization.userRole.UserRoleService
-import com.service.authorization.userRole.toGrantedAuthority
+import com.service.authorization.userRole.*
 import org.slf4j.LoggerFactory
-import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
 import org.springframework.security.oauth2.core.oidc.OidcIdToken
@@ -52,8 +49,11 @@ class CustomOAuth2UserService(
         userFederatedIdentityService.getOrSave(userRequest.idToken.subject, userId, userRequest.clientRegistration.registrationId)
     }
 
-    private fun getAllOrSaveUserRole(userId: String) =
-            userRoleService.getAllOrSave(userId, listOf(SimpleGrantedAuthority(SecurityConstants.ROLE_USER)))
+    private fun getAllOrSaveUserRole(userId: String):List<GrantedAuthority> {
+        val payload = UserRoleCreationPayload(UserRoleType.ROLE_USER)
+        return userRoleService.getAllOrSave(userId, payload)
+    }
+
 
     private fun getOrSaveUser(email: String) = userService.getBy(email = email)
             ?: userService.save(UserCreationPayload(email = email, password = ""))

--- a/src/main/kotlin/com/service/authorization/oauth/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/service/authorization/oauth/CustomOAuth2UserService.kt
@@ -50,7 +50,7 @@ class CustomOAuth2UserService(
     }
 
     private fun getAllOrSaveUserRole(userId: String):List<GrantedAuthority> {
-        val payload = UserRoleCreationPayload(UserRoleType.ROLE_USER)
+        val payload = UserRoleCreationPayload(UserRoleName.ROLE_USER)
         return userRoleService.getAllOrSave(userId, payload)
     }
 

--- a/src/main/kotlin/com/service/authorization/user/UserNameAndPasswordService.kt
+++ b/src/main/kotlin/com/service/authorization/user/UserNameAndPasswordService.kt
@@ -1,8 +1,9 @@
 package com.service.authorization.user
 
+import com.service.authorization.userRole.UserRole
 import com.service.authorization.userRole.UserRoleService
+import com.service.authorization.userRole.toGrantedAuthority
 import org.slf4j.LoggerFactory
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
@@ -14,7 +15,7 @@ class UserNameAndPasswordService(
     private val logger = LoggerFactory.getLogger(this.javaClass)
     override fun loadUserByUsername(username: String): UserDetails {
         val user = userService.getBy(username) ?: throw Exception("없는 회원 입니다")
-        val roles = userRoleService.getAllBy(user.id).map { SimpleGrantedAuthority(it.role) }
+        val roles = userRoleService.getAllBy(user.id).map(UserRole::toGrantedAuthority)
         logger.debug("authenticated user: ${user.email}")
         return User.builder().username(user.id).password(user.password).authorities(roles).build()
     }

--- a/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
@@ -21,9 +21,9 @@ class UserRole(
         val userId: String,
 
         /**
-         * 권한
+         * 권한 이름
          */
-        val role: String
+        val name: String
 ) {
     companion object {
         /**
@@ -32,7 +32,7 @@ class UserRole(
         fun of(userId: String, authority: GrantedAuthority) = UserRole(
                 id = UUID.randomUUID().toString(),
                 userId = userId,
-                role = authority.authority
+                name = authority.authority
         )
     }
 }

--- a/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
@@ -23,7 +23,7 @@ class UserRole(
          * 권한 이름
          */
         @Enumerated(EnumType.STRING)
-        val name: UserRoleType
+        val name: UserRoleName
 ) {
     private constructor(builder: Builder) : this(builder.id!!, builder.userId, builder.name!!)
 
@@ -36,7 +36,7 @@ class UserRole(
     class Builder {
         var id: String? = UUID.randomUUID().toString()
         var userId: String = ""
-        var name: UserRoleType? = null
+        var name: UserRoleName? = null
 
         fun build(): UserRole {
             return UserRole(this)

--- a/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
@@ -1,7 +1,6 @@
 package com.service.authorization.userRole
 
 import jakarta.persistence.*
-import org.springframework.security.core.GrantedAuthority
 import java.util.UUID
 
 /**
@@ -23,29 +22,21 @@ class UserRole(
         /**
          * 권한 이름
          */
-        val name: String
+        @Enumerated(EnumType.STRING)
+        val name: UserRoleType
 ) {
-    private constructor(builder: Builder) : this(builder.id!!, builder.userId, builder.name)
+    private constructor(builder: Builder) : this(builder.id!!, builder.userId, builder.name!!)
 
     companion object {
 
         inline fun userRole(block: Builder.() -> Unit) = Builder().apply(block).build()
-
-        /**
-         * 회원 권한 객체 생성
-         */
-        fun of(userId: String, authority: GrantedAuthority) = UserRole(
-                id = UUID.randomUUID().toString(),
-                userId = userId,
-                name = authority.authority
-        )
     }
 
 
     class Builder {
         var id: String? = UUID.randomUUID().toString()
         var userId: String = ""
-        var name: String = ""
+        var name: UserRoleType? = null
 
         fun build(): UserRole {
             return UserRole(this)

--- a/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRole.kt
@@ -25,7 +25,12 @@ class UserRole(
          */
         val name: String
 ) {
+    private constructor(builder: Builder) : this(builder.id!!, builder.userId, builder.name)
+
     companion object {
+
+        inline fun userRole(block: Builder.() -> Unit) = Builder().apply(block).build()
+
         /**
          * 회원 권한 객체 생성
          */
@@ -34,5 +39,16 @@ class UserRole(
                 userId = userId,
                 name = authority.authority
         )
+    }
+
+
+    class Builder {
+        var id: String? = UUID.randomUUID().toString()
+        var userId: String = ""
+        var name: String = ""
+
+        fun build(): UserRole {
+            return UserRole(this)
+        }
     }
 }

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleController.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleController.kt
@@ -22,7 +22,7 @@ class UserRoleController(
     @GetMapping("/console/users/{userId}/roles/views/creation")
     fun getCreationView(@PathVariable userId: String, model: Model): String {
         model.addAttribute("userId", userId)
-        model.addAttribute("roles", UserRoleType.values())
+        model.addAttribute("roles", UserRoleName.values())
         return "users/roles/creation"
     }
 

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleController.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleController.kt
@@ -1,9 +1,11 @@
 package com.service.authorization.userRole
 
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 
 @Controller
 class UserRoleController(
@@ -22,5 +24,11 @@ class UserRoleController(
         model.addAttribute("userId", userId)
         model.addAttribute("roles", UserRoleType.values())
         return "users/roles/creation"
+    }
+
+    @PostMapping("/console/users/{userId}/roles", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    fun save(@PathVariable userId: String, payload: UserRoleCreationPayload): String {
+        userRoleService.save(userId, payload)
+        return "redirect:/console/users/${userId}/roles"
     }
 }

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleController.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleController.kt
@@ -16,4 +16,11 @@ class UserRoleController(
         model.addAttribute("roles", userRoleService.getAllBy(userId))
         return "users/roles/main"
     }
+
+    @GetMapping("/console/users/{userId}/roles/views/creation")
+    fun getCreationView(@PathVariable userId: String, model: Model): String {
+        model.addAttribute("userId", userId)
+        model.addAttribute("roles", UserRoleType.values())
+        return "users/roles/creation"
+    }
 }

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleCreationPayload.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleCreationPayload.kt
@@ -4,5 +4,5 @@ package com.service.authorization.userRole
  * 회원 권한 생성 필드 데이터
  */
 data class UserRoleCreationPayload(
-        val name: UserRoleType
+        val name: UserRoleName
 )

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleCreationPayload.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleCreationPayload.kt
@@ -1,0 +1,8 @@
+package com.service.authorization.userRole
+
+/**
+ * 회원 권한 생성 필드 데이터
+ */
+data class UserRoleCreationPayload(
+        val name: UserRoleType
+)

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleExtension.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleExtension.kt
@@ -3,4 +3,4 @@ package com.service.authorization.userRole
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 
-fun UserRole.toGrantedAuthority() = SimpleGrantedAuthority(this.role)
+fun UserRole.toGrantedAuthority() = SimpleGrantedAuthority(this.name)

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleExtension.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleExtension.kt
@@ -3,4 +3,4 @@ package com.service.authorization.userRole
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 
-fun UserRole.toGrantedAuthority() = SimpleGrantedAuthority(this.name)
+fun UserRole.toGrantedAuthority() = SimpleGrantedAuthority(this.name.toString())

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleName.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleName.kt
@@ -1,5 +1,5 @@
 package com.service.authorization.userRole
 
-enum class UserRoleType {
+enum class UserRoleName {
     ROLE_ADMIN, ROLE_USER
 }

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
@@ -1,5 +1,6 @@
 package com.service.authorization.userRole
 
+import com.service.authorization.userRole.UserRole.Companion.userRole
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.stereotype.Service
 
@@ -20,6 +21,15 @@ class UserRoleService(
             authorities.map { UserRole.of(userId, it) }.run {
                 userRoleRepository.saveAll(this)
             }
+
+    fun save(userId: String, payload: UserRoleCreationPayload): UserRole {
+        val count = userRoleRepository.findByUserId(userId).count { it.name == payload.name.name }
+        if (count > 0) throw Exception("이미 등록된 권한입니다")
+        return userRole {
+            this.userId = userId
+            this.name = payload.name.name
+        }.run(userRoleRepository::save)
+    }
 
     fun getAllBy(userId: String): List<UserRole> =
             userRoleRepository.findByUserId(userId)

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
@@ -9,25 +9,21 @@ class UserRoleService(
         private val userRoleRepository: UserRoleRepository
 ) {
 
-    fun getAllOrSave(userId: String, authorities: List<GrantedAuthority>): List<GrantedAuthority> {
+    fun getAllOrSave(userId: String, payload: UserRoleCreationPayload): List<GrantedAuthority> {
         val roles = getAllBy(userId = userId).map(UserRole::toGrantedAuthority)
-        if (roles.containsAll(authorities)) {
+        if (roles.isNotEmpty()) {
             return roles
         }
-        return saveAll(userId, authorities).map(UserRole::toGrantedAuthority)
+
+        return listOf(save(userId, payload).toGrantedAuthority())
     }
 
-    fun saveAll(userId: String, authorities: List<GrantedAuthority>): List<UserRole> =
-            authorities.map { UserRole.of(userId, it) }.run {
-                userRoleRepository.saveAll(this)
-            }
-
     fun save(userId: String, payload: UserRoleCreationPayload): UserRole {
-        val count = userRoleRepository.findByUserId(userId).count { it.name == payload.name.name }
+        val count = userRoleRepository.findByUserId(userId).count { it.name == payload.name }
         if (count > 0) throw Exception("이미 등록된 권한입니다")
         return userRole {
             this.userId = userId
-            this.name = payload.name.name
+            this.name = payload.name
         }.run(userRoleRepository::save)
     }
 

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleService.kt
@@ -1,7 +1,6 @@
 package com.service.authorization.userRole
 
 import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Service
 
 @Service
@@ -10,11 +9,11 @@ class UserRoleService(
 ) {
 
     fun getAllOrSave(userId: String, authorities: List<GrantedAuthority>): List<GrantedAuthority> {
-        val roles = getAllBy(userId = userId).map { SimpleGrantedAuthority(it.role) }
+        val roles = getAllBy(userId = userId).map(UserRole::toGrantedAuthority)
         if (roles.containsAll(authorities)) {
             return roles
         }
-        return saveAll(userId, authorities).map { SimpleGrantedAuthority(it.role) }
+        return saveAll(userId, authorities).map(UserRole::toGrantedAuthority)
     }
 
     fun saveAll(userId: String, authorities: List<GrantedAuthority>): List<UserRole> =

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleType.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleType.kt
@@ -1,0 +1,5 @@
+package com.service.authorization.userRole
+
+enum class UserRoleType {
+    ROLE_ADMIN, ROLE_USER
+}

--- a/src/main/resources/db/migration/V202303190903__user_role.sql
+++ b/src/main/resources/db/migration/V202303190903__user_role.sql
@@ -1,5 +1,3 @@
--- 회원 권한 테이블
--- name column 추가
-ALTER TABLE user_role ADD COLUMN name varchar(100) NOT NULL;
--- role column 제거
-ALTER TABLE user_role DROP role;
+-- 회원 권한 테이블 컬럼 이름 수정
+
+ALTER TABLE user_role RENAME COLUMN role TO name;

--- a/src/main/resources/db/migration/V202303190903__user_role.sql
+++ b/src/main/resources/db/migration/V202303190903__user_role.sql
@@ -1,0 +1,5 @@
+-- 회원 권한 테이블
+-- name column 추가
+ALTER TABLE user_role ADD COLUMN name varchar(100) NOT NULL;
+-- role column 제거
+ALTER TABLE user_role DROP role;

--- a/src/main/resources/templates/users/roles/creation.html
+++ b/src/main/resources/templates/users/roles/creation.html
@@ -7,9 +7,9 @@
         </p>
     </div>
 
-    <form th:action="@{/console/users}" th:method="post">
+    <form th:action="@{/console/users/{userId}/roles(userId = ${userId})}" th:method="post">
         <div class="mb-3">
-            <select class="form-select" aria-label="Default select example" style="width:200px">
+            <select class="form-select" name="name" aria-label="Default select example" style="width:200px">
                 <option selected>선택해주세요</option>
                 <th:block th:each="role : ${roles}">
                     <option th:value="${role}" th:text="${role}"/>

--- a/src/main/resources/templates/users/roles/creation.html
+++ b/src/main/resources/templates/users/roles/creation.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{users/layout/detail-layout}">
+<th:block layout:fragment="detail-content">
+    <div>
+        <p class="display-5">
+            user role 생성
+        </p>
+    </div>
+
+    <form th:action="@{/console/users}" th:method="post">
+        <div class="mb-3">
+            <select class="form-select" aria-label="Default select example" style="width:200px">
+                <option selected>선택해주세요</option>
+                <th:block th:each="role : ${roles}">
+                    <option th:value="${role}" th:text="${role}"/>
+                </th:block>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary">저장</button>
+    </form>
+</th:block>
+</html>

--- a/src/main/resources/templates/users/roles/main.html
+++ b/src/main/resources/templates/users/roles/main.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{users/layout/detail-layout}">
 <th:block layout:fragment="detail-content">
+    <a class="btn btn-primary" th:href="@{/console/users/{userId}/roles/views/creation(userId = ${userId})}" role="button">추가</a>
+    <a class="btn btn-primary" role="button" th:onclick="deleteUsers()">선택 항목 제거</a>
     <table class="table table-bordered table-hover" style="table-layout: fixed;">
         <thead>
         <tr>

--- a/src/main/resources/templates/users/roles/main.html
+++ b/src/main/resources/templates/users/roles/main.html
@@ -8,14 +8,14 @@
         <tr>
             <th style="width:50px"></th>
             <th><span>id</span></th>
-            <th><span>role</span></th>
+            <th><span>name</span></th>
         </tr>
         </thead>
         <tbody>
         <tr th:each="role : ${roles}">
             <td><input class="form-check-input" name="checkId" type="checkbox" th:value="${role.id}"></td>
             <td><span class="d-block text-truncate" th:text="${role.id}"></span></td>
-            <td><span class="d-block text-truncate" th:text="${role.role}"></span></td>
+            <td><span class="d-block text-truncate" th:text="${role.name}"></span></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## 요약
- 회원 권한 생성 페이지 추가
- 회원 권한 생성 api 추가
- 회원 권한 로직 리팩토링
### entity
- 필드 변경: role -> name 
### schema
- user_role 컬럼 수정
### refactoring
- 회원 권한 저장 및 생성시 payload 로 처리
- 회원 권한은 enum class 로 관리