### PR TITLE
refactor: 승인 코드 요청시 쿠키로 관리

### DIFF
--- a/src/main/kotlin/com/service/authorization/config/Oauth2Config.kt
+++ b/src/main/kotlin/com/service/authorization/config/Oauth2Config.kt
@@ -1,6 +1,7 @@
 package com.service.authorization.config
 
 import com.service.authorization.federatedIdentity.FederatedIdentityConfigurer
+import com.service.authorization.oauth.HttpCookieOauth2AuthorizationRequestRepository
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
@@ -13,8 +14,9 @@ class Oauth2Config(
         private val clientRegistrationRepository: ClientRegistrationRepository,
         private val customerOAuth2UserService: OAuth2UserService<OidcUserRequest, OidcUser>
 ) {
+    private val httpCookieOauth2AuthorizationRequestRepository = HttpCookieOauth2AuthorizationRequestRepository()
 
     val federatedIdentityConfig: FederatedIdentityConfigurer
-        get() = FederatedIdentityConfigurer(clientRegistrationRepository, customerOAuth2UserService)
+        get() = FederatedIdentityConfigurer(clientRegistrationRepository, customerOAuth2UserService, httpCookieOauth2AuthorizationRequestRepository)
 
 }

--- a/src/main/kotlin/com/service/authorization/federatedIdentity/FederatedIdentityConfigurer.kt
+++ b/src/main/kotlin/com/service/authorization/federatedIdentity/FederatedIdentityConfigurer.kt
@@ -1,22 +1,31 @@
 package com.service.authorization.federatedIdentity
 
 import com.service.authorization.config.SecurityConstants
+import com.service.authorization.oauth.HttpCookieOauth2AuthorizationRequestRepository
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.security.web.savedrequest.CookieRequestCache
 
 class FederatedIdentityConfigurer(
         private val clientRegistrationRepository: ClientRegistrationRepository,
-        private val customerOAuth2UserService: OAuth2UserService<OidcUserRequest, OidcUser>
+        private val customerOAuth2UserService: OAuth2UserService<OidcUserRequest, OidcUser>,
+        private val httpCookieOauth2AuthorizationRequestRepository: HttpCookieOauth2AuthorizationRequestRepository
 ) : AbstractHttpConfigurer<FederatedIdentityConfigurer, HttpSecurity>() {
 
     override fun init(http: HttpSecurity) {
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        http.requestCache().requestCache(CookieRequestCache())
         http.exceptionHandling { exceptions ->
             exceptions.authenticationEntryPoint(FederatedIdentityAuthenticationEntryPoint(clientRegistrationRepository))
         }.oauth2Login()
+                .authorizationEndpoint()
+                .authorizationRequestRepository(httpCookieOauth2AuthorizationRequestRepository)
+                .and()
                 .defaultSuccessUrl(SecurityConstants.SUCCESS_URL)
                 .userInfoEndpoint()
                 .oidcUserService(customerOAuth2UserService)

--- a/src/main/kotlin/com/service/authorization/oauth/HttpCookieOauth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/service/authorization/oauth/HttpCookieOauth2AuthorizationRequestRepository.kt
@@ -1,0 +1,68 @@
+package com.service.authorization.oauth
+
+import com.service.authorization.util.CookieUtils
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames
+import org.springframework.util.Assert
+
+class HttpCookieOauth2AuthorizationRequestRepository : AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private val authorizationRequestName = HttpCookieOauth2AuthorizationRequestRepository::class.java
+            .name + ".AUTHORIZATION_REQUEST"
+    private val redirectUriName = "redirect_uri"
+
+    private val maxAge = 180
+
+    override fun loadAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? {
+        Assert.notNull(request, "request cannot be null")
+        val stateParameter = getStateParameter(request) ?: return null
+        val authorizationRequest = getAuthorizationRequest(request) ?: return null
+        if (authorizationRequest.state != stateParameter) return null
+        return authorizationRequest
+    }
+
+    override fun saveAuthorizationRequest(authorizationRequest: OAuth2AuthorizationRequest?, request: HttpServletRequest,
+                                          response: HttpServletResponse) {
+        Assert.notNull(request, "request cannot be null")
+        Assert.notNull(response, "response cannot be null")
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response)
+            return
+        }
+        val state = authorizationRequest.state
+        Assert.hasText(state, "authorizationRequest.state cannot be empty")
+        val authorizationRequestSerializer = CookieUtils.serialize(authorizationRequest)
+        CookieUtils.addCookie(response, authorizationRequestName, authorizationRequestSerializer, maxAge)
+        val redirectUri = request.getParameter(redirectUriName)
+        if (!redirectUri.isNullOrBlank()) {
+            CookieUtils.addCookie(response, redirectUriName, redirectUri, maxAge)
+        }
+    }
+
+    override fun removeAuthorizationRequest(request: HttpServletRequest, response: HttpServletResponse): OAuth2AuthorizationRequest? {
+        Assert.notNull(response, "response cannot be null")
+        val authorizationRequest = loadAuthorizationRequest(request)
+        if (authorizationRequest != null) {
+            CookieUtils.deleteCookie(request, response, authorizationRequestName)
+            CookieUtils.deleteCookie(request, response, redirectUriName)
+        }
+        return authorizationRequest
+    }
+
+    /**
+     * Gets the state parameter from the [HttpServletRequest]
+     * @param request the request to use
+     * @return the state parameter or null if not found
+     */
+    private fun getStateParameter(request: HttpServletRequest): String? {
+        return request.getParameter(OAuth2ParameterNames.STATE)
+    }
+
+    private fun getAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? {
+        val cookie = CookieUtils.getCookie(request, authorizationRequestName) ?: return null
+        return CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest::class.java)
+    }
+}

--- a/src/main/kotlin/com/service/authorization/util/CookieUtil.kt
+++ b/src/main/kotlin/com/service/authorization/util/CookieUtil.kt
@@ -1,0 +1,43 @@
+package com.service.authorization.util
+
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.util.SerializationUtils
+import java.util.*
+
+
+object CookieUtils {
+    fun getCookie(request: HttpServletRequest, name: String): Cookie? {
+        val cookies: Array<Cookie> = request.cookies
+        return cookies.firstOrNull { it.name == name }
+    }
+
+    fun addCookie(response: HttpServletResponse, name: String, value: String, maxAge: Int) {
+        Cookie(name, value).run {
+            this.path = "/"
+            this.isHttpOnly = true
+            this.maxAge = maxAge
+            response.addCookie(this)
+        }
+    }
+
+    fun deleteCookie(request: HttpServletRequest, response: HttpServletResponse, name: String) {
+        request.cookies.firstOrNull { it.name == name }?.run {
+            this.value = ""
+            this.path = "/"
+            this.maxAge = 0
+            response.addCookie(this)
+        }
+    }
+
+    fun serialize(`object`: Any): String {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(`object`))
+    }
+
+    fun <T> deserialize(cookie: Cookie, cls: Class<T>): T {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.value)))
+    }
+}


### PR DESCRIPTION
## 요약
- 승인코드 요청시 데이터 저장방식 수정: session -> cookie
- oauth2 인증 로직에서는 session 을 stateless 로관리
 