### PR TITLE
refactor: oidc introspect 설정 수정

### DIFF
--- a/src/main/kotlin/com/service/authorization/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/service/authorization/config/SecurityConfig.kt
@@ -1,7 +1,9 @@
 package com.service.authorization.config
 
+import com.service.authorization.oauth.OAuth2TokenIntrospectionAuthenticationSuccessHandler
 import com.service.authorization.oauth.Oauth2AuthorizationAuthenticationSuccessHandler
 import com.service.authorization.userRole.UserRoleName
+import com.service.authorization.userRole.UserRoleService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
@@ -21,7 +23,8 @@ import java.util.*
 @Configuration
 class SecurityConfig(
         private val oauth2Config: Oauth2Config,
-        private val jwtDecoder: JwtDecoder
+        private val jwtDecoder: JwtDecoder,
+        private val userRoleService: UserRoleService
 ) {
 
     @Bean
@@ -30,9 +33,12 @@ class SecurityConfig(
     fun authorizationServerSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http)
         http.getConfigurer(OAuth2AuthorizationServerConfigurer::class.java)
+                //.oidc(Customizer.withDefaults()) // Enable OpenID Connect 1.0
                 .oidc(Customizer.withDefaults()) // Enable OpenID Connect 1.0
                 .authorizationEndpoint { endpoint ->
                     endpoint.authorizationResponseHandler(Oauth2AuthorizationAuthenticationSuccessHandler())
+                }.tokenIntrospectionEndpoint { endpoint ->
+                    endpoint.introspectionResponseHandler(OAuth2TokenIntrospectionAuthenticationSuccessHandler(userRoleService))
                 }
         http.exceptionHandling { exceptions ->
             exceptions

--- a/src/main/kotlin/com/service/authorization/oauth/OAuth2TokenIntrospectionAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/service/authorization/oauth/OAuth2TokenIntrospectionAuthenticationSuccessHandler.kt
@@ -1,0 +1,51 @@
+package com.service.authorization.oauth
+
+import com.service.authorization.userRole.UserRoleService
+import com.service.authorization.userRole.excludeAdmin
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.server.ServletServerHttpResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenIntrospection
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2TokenIntrospectionAuthenticationToken
+import org.springframework.security.oauth2.server.authorization.http.converter.OAuth2TokenIntrospectionHttpMessageConverter
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+
+/**
+ * token-introspect 검증 끝난후 처리 로직
+ */
+class OAuth2TokenIntrospectionAuthenticationSuccessHandler(
+        private val userRoleService: UserRoleService
+) : AuthenticationSuccessHandler {
+    private val tokenIntrospectionHttpResponseConverter = OAuth2TokenIntrospectionHttpMessageConverter()
+    override fun onAuthenticationSuccess(request: HttpServletRequest, response: HttpServletResponse, authentication: Authentication) {
+        val tokenIntrospectionAuthentication = authentication as OAuth2TokenIntrospectionAuthenticationToken
+        val clientPrincipal = tokenIntrospectionAuthentication.principal as OAuth2ClientAuthenticationToken
+        val authorizationGrantTypes = clientPrincipal.registeredClient?.authorizationGrantTypes
+        val tokenIntrospection = tokenIntrospectionAuthentication.tokenClaims
+        val claims = tokenIntrospectionAuthentication.tokenClaims.claims.toMutableMap()
+        if (tokenIntrospection.isActive) {
+            claims.putAll(additionalClaims(tokenIntrospection.subject, authorizationGrantTypes))
+        }
+        val token = OAuth2TokenIntrospection.withClaims(claims).build()
+        val httpResponse = ServletServerHttpResponse(response)
+        this.tokenIntrospectionHttpResponseConverter.write(token, null, httpResponse)
+    }
+
+    /**
+     * 회원 번호로 조회한 정보를 claims 으로 추가하는 로직
+     * 회원 번호가 있는 경우
+     * register-client authorizationGrantTypes 이 client_credentials 을 포함한 경우에만 허용한다
+     */
+    private fun additionalClaims(userId: String?, authorizationGrantTypes: Set<AuthorizationGrantType>?): Map<String, Any> {
+        val claims = mutableMapOf<String, Any>()
+        if (userId == null || authorizationGrantTypes == null) return emptyMap()
+        if (authorizationGrantTypes.count { it == AuthorizationGrantType.CLIENT_CREDENTIALS } == 0) return emptyMap()
+        userRoleService.getAllBy(userId).excludeAdmin().ifEmpty { null }?.map { it.name.toString() }?.run {
+            claims.putIfAbsent("roles", this)
+        }
+        return claims
+    }
+}

--- a/src/main/kotlin/com/service/authorization/userRole/UserRoleExtension.kt
+++ b/src/main/kotlin/com/service/authorization/userRole/UserRoleExtension.kt
@@ -4,3 +4,5 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 
 fun UserRole.toGrantedAuthority() = SimpleGrantedAuthority(this.name.toString())
+
+fun List<UserRole>.excludeAdmin() = this.filter { it.name != UserRoleName.ROLE_ADMIN }

--- a/src/test/kotlin/com/service/authorization/config/TestSecurityConfig.kt
+++ b/src/test/kotlin/com/service/authorization/config/TestSecurityConfig.kt
@@ -2,6 +2,7 @@ package com.service.authorization.config
 
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.MockkBeans
+import com.service.authorization.userRole.UserRoleService
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.core.Ordered
@@ -19,9 +20,10 @@ import org.springframework.security.web.SecurityFilterChain
 @TestConfiguration
 class TestSecurityConfig(
         oauth2Config: Oauth2Config,
-        jwtDecoder: JwtDecoder
+        jwtDecoder: JwtDecoder,
+        userRoleService: UserRoleService
 ) {
-    private val securityConfigImpl = SecurityConfig(oauth2Config, jwtDecoder)
+    private val securityConfigImpl = SecurityConfig(oauth2Config, jwtDecoder, userRoleService)
 
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE)


### PR DESCRIPTION
## 요약
- introspect 인증 성공후 관리자 권한 제외하고 회원 권한 정보를 claim 추가한다
- 조건
  - client 인증 성공한 경우
  - subject 헤더가 있는 경우
  - client 승인 타입이 `client_credentials` 인 경우
